### PR TITLE
Initialize backend directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build Backend docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: false
+          tags: terrascope/terrascope-api:${{ github.sha }}
+
+  test:
+    defaults:
+      run:
+        working-directory: backend
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "backend/go.mod"
+          cache-dependency-path: "backend/go.sum"
+
+      - name: Run tests
+        run: |
+          go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.vscode/*
+*.idea
+.DS_Store
+.env
+bin/
+examples/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 LeCafeCloud nadmax
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# TerraScope
+![CI](https://github.com/LeCafeCloud/terrascope/actions/workflows/ci.yml/badge.svg)
+
+# Terrascope
 
 A web app that turns your **Terraform state into an interactive constellation**.  
 Resources become planets, modules become galaxies, and dependencies form orbital links.
@@ -36,6 +38,7 @@ The goal is to learn, explain, and audit infra relationships through an intuitiv
 > Feel free to change names, visuals, or rules.
 
 ### Visual Mappings
+
 | Terraform Concept | TerraScope Metaphor | Example Visualization |
 |-------------------|---------------------|-----------------------|
 | Provider          | Star type           | Color or spectrum per provider |
@@ -46,12 +49,14 @@ The goal is to learn, explain, and audit infra relationships through an intuitiv
 | Drift or taint    | Storm cloud         | Particle effect or outline |
 
 ### Views
+
 - **Constellation view**: force-directed graph of resources and modules  
 - **Orbit view**: module-centric “solar system” where resources orbit modules  
 - **Timeline**: play changes across commits or releases  
 - **Policy lens**: highlight resources violating tagging or compliance rules
 
 ### Interactions
+
 - Click to open a resource panel: type, provider, attributes (sanitized), lifecycle, dependencies  
 - Filter by provider, module, tag, environment  
 - Search bar with fuzzy search on addresses (`module.app.aws_s3_bucket.assets`)  
@@ -92,7 +97,6 @@ Terraform State (local upload or remote backend)
 => Frontend (React/Svelte + Three.js/D3)
 => Interactive Constellation UI
 ```
-
 
 ---
 

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+README.md
+.git
+.gitignore

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.25.3-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY ./ ./
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w" -o terrascope ./cmd/api/
+
+FROM alpine:3.22 AS final
+RUN apk --no-cache add ca-certificates=20250911-r0
+WORKDIR /app
+COPY --from=builder /app/terrascope ./
+EXPOSE 8080
+ENTRYPOINT [ "./terrascope" ]

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,0 +1,19 @@
+// Package main starts an HTTP server that provides endpoints for health checks
+// and Terraform state parsing. It uses the internal handlers package to process
+// incoming requests and return JSON responses.
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/terrascope/core/internal/handlers"
+)
+
+func main() {
+	http.HandleFunc("/health", handlers.HealthHandler)
+	http.HandleFunc("/parse", handlers.ParseHandler)
+
+	log.Printf("🚀 Server starting on 8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/backend/cmd/api/main_test.go
+++ b/backend/cmd/api/main_test.go
@@ -1,0 +1,361 @@
+// Package main starts an HTTP server that provides endpoints for health checks
+// and Terraform state parsing. It uses the internal handlers package to process
+// incoming requests and return JSON responses.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terrascope/core/internal/handlers"
+	"github.com/terrascope/core/internal/models"
+)
+
+func setupRouter() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", handlers.HealthHandler)
+	mux.HandleFunc("/parse", handlers.ParseHandler)
+	return mux
+}
+
+func TestMainRoutes(t *testing.T) {
+	router := setupRouter()
+
+	t.Run("health endpoint is accessible", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	})
+
+	t.Run("parse endpoint is accessible", func(t *testing.T) {
+		validTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": []
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(validTfstate))
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	})
+
+	t.Run("non-existent route returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("root path returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func TestHealthEndpointIntegration(t *testing.T) {
+	router := setupRouter()
+
+	t.Run("health returns valid response structure", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		var response handlers.HealthResponse
+		err := json.NewDecoder(w.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.Equal(t, "healthy", response.Status)
+		assert.Equal(t, "terrascope-api", response.Service)
+		assert.NotEmpty(t, response.Timestamp)
+		assert.NotEmpty(t, response.Uptime)
+	})
+
+	t.Run("health endpoint rejects POST", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/health", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+}
+
+func TestParseEndpointIntegration(t *testing.T) {
+	router := setupRouter()
+
+	t.Run("parse returns valid graph", func(t *testing.T) {
+		tfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_vpc",
+					"name": "main",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [{
+						"schema_version": 1,
+						"attributes": {"id": "vpc-123"}
+					}]
+				}
+			]
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(tfstate))
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var graph models.Graph
+		err := json.NewDecoder(w.Body).Decode(&graph)
+		require.NoError(t, err)
+
+		assert.Len(t, graph.Nodes, 1)
+		assert.Equal(t, "aws_vpc.main", graph.Nodes[0].ID)
+	})
+
+	t.Run("parse rejects GET requests", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/parse", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("parse rejects invalid JSON", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader("invalid"))
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestEndToEndFlow(t *testing.T) {
+	router := setupRouter()
+
+	t.Run("complete workflow: health check then parse", func(t *testing.T) {
+		healthReq := httptest.NewRequest(http.MethodGet, "/health", nil)
+		healthW := httptest.NewRecorder()
+		router.ServeHTTP(healthW, healthReq)
+		assert.Equal(t, http.StatusOK, healthW.Code)
+
+		tfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_s3_bucket",
+					"name": "assets",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [{
+						"schema_version": 0,
+						"attributes": {"id": "my-bucket"}
+					}]
+				},
+				{
+					"mode": "managed",
+					"type": "aws_s3_bucket_policy",
+					"name": "assets_policy",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [{
+						"schema_version": 0,
+						"attributes": {"id": "my-bucket-policy"},
+						"dependencies": ["aws_s3_bucket.assets"]
+					}]
+				}
+			]
+		}`
+
+		parseReq := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(tfstate))
+		parseW := httptest.NewRecorder()
+		router.ServeHTTP(parseW, parseReq)
+
+		assert.Equal(t, http.StatusOK, parseW.Code)
+
+		var graph models.Graph
+		err := json.NewDecoder(parseW.Body).Decode(&graph)
+		require.NoError(t, err)
+
+		assert.Len(t, graph.Nodes, 2)
+		assert.Len(t, graph.Edges, 1)
+	})
+}
+
+func TestRoutePaths(t *testing.T) {
+	router := setupRouter()
+
+	testCases := []struct {
+		name           string
+		path           string
+		method         string
+		expectedStatus int
+	}{
+		{"health with GET", "/health", http.MethodGet, http.StatusOK},
+		{"health with POST", "/health", http.MethodPost, http.StatusMethodNotAllowed},
+		{"parse with POST", "/parse", http.MethodPost, http.StatusBadRequest},
+		{"parse with GET", "/parse", http.MethodGet, http.StatusMethodNotAllowed},
+		{"unknown path", "/unknown", http.MethodGet, http.StatusNotFound},
+		{"root path", "/", http.MethodGet, http.StatusNotFound},
+		{"health with trailing slash", "/health/", http.MethodGet, http.StatusNotFound},
+		{"parse with trailing slash", "/parse/", http.MethodPost, http.StatusNotFound},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.expectedStatus, w.Code)
+		})
+	}
+}
+
+func TestConcurrentRequests(t *testing.T) {
+	router := setupRouter()
+
+	t.Run("handles concurrent health checks", func(t *testing.T) {
+		numRequests := 50
+		results := make(chan int, numRequests)
+
+		for range numRequests {
+			go func() {
+				req := httptest.NewRequest(http.MethodGet, "/health", nil)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+				results <- w.Code
+			}()
+		}
+
+		for range numRequests {
+			code := <-results
+			assert.Equal(t, http.StatusOK, code)
+		}
+	})
+
+	t.Run("handles concurrent parse requests", func(t *testing.T) {
+		tfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": []
+		}`
+
+		numRequests := 50
+		results := make(chan int, numRequests)
+
+		for range numRequests {
+			go func() {
+				req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(tfstate))
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+				results <- w.Code
+			}()
+		}
+
+		for range numRequests {
+			code := <-results
+			assert.Equal(t, http.StatusOK, code)
+		}
+	})
+
+	t.Run("handles mixed concurrent requests", func(t *testing.T) {
+		numRequests := 100
+		results := make(chan int, numRequests)
+
+		tfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": []
+		}`
+
+		for i := range numRequests {
+			go func(index int) {
+				var req *http.Request
+				if index%2 == 0 {
+					req = httptest.NewRequest(http.MethodGet, "/health", nil)
+				} else {
+					req = httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(tfstate))
+				}
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+				results <- w.Code
+			}(i)
+		}
+
+		for range numRequests {
+			code := <-results
+			assert.Equal(t, http.StatusOK, code)
+		}
+	})
+}
+
+func TestContentTypeHeaders(t *testing.T) {
+	router := setupRouter()
+
+	t.Run("all successful responses return application/json", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			method string
+			path   string
+			body   string
+		}{
+			{"health endpoint", http.MethodGet, "/health", ""},
+			{"parse endpoint", http.MethodPost, "/parse", `{"version":4,"terraform_version":"1.5.0","serial":1,"lineage":"abc","resources":[]}`},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var req *http.Request
+				if tt.body != "" {
+					req = httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+				} else {
+					req = httptest.NewRequest(tt.method, tt.path, nil)
+				}
+
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+
+				if w.Code == http.StatusOK {
+					assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+				}
+			})
+		}
+	})
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,11 @@
+module github.com/terrascope/core
+
+go 1.25.3
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/internal/handlers/health.go
+++ b/backend/internal/handlers/health.go
@@ -1,0 +1,45 @@
+// Package handlers provides HTTP request handlers for the API endpoints.
+// It defines the routing logic, response formatting, and error handling mechanisms.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+type HealthResponse struct {
+	Status    string            `json:"status"`
+	Timestamp string            `json:"timestamp"`
+	Service   string            `json:"service"`
+	Uptime    string            `json:"uptime,omitempty"`
+	Details   map[string]string `json:"details,omitempty"`
+}
+
+var startTime = time.Now()
+
+func HealthHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	response := HealthResponse{
+		Status:    "healthy",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Service:   "terrascope-api",
+		Uptime:    time.Since(startTime).String(),
+		Details: map[string]string{
+			"go_version": runtime.Version(),
+			"num_cpu":    string(rune(runtime.NumCPU())),
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}

--- a/backend/internal/handlers/health_test.go
+++ b/backend/internal/handlers/health_test.go
@@ -1,0 +1,269 @@
+// Package handlers provides HTTP request handlers for the API endpoints.
+// It defines the routing logic, response formatting, and error handling mechanisms.
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthHandler(t *testing.T) {
+	t.Run("returns 200 OK for GET request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("returns correct content type", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	})
+
+	t.Run("returns valid JSON response", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		var response HealthResponse
+		err := json.NewDecoder(w.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.Equal(t, "healthy", response.Status)
+		assert.Equal(t, "terrascope-api", response.Service)
+		assert.NotEmpty(t, response.Timestamp)
+		assert.NotEmpty(t, response.Uptime)
+	})
+
+	t.Run("timestamp is in RFC3339 format", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		var response HealthResponse
+		err := json.NewDecoder(w.Body).Decode(&response)
+		require.NoError(t, err)
+
+		_, err = time.Parse(time.RFC3339, response.Timestamp)
+		assert.NoError(t, err, "Timestamp should be valid RFC3339 format")
+	})
+
+	t.Run("includes Go version in details", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		var response HealthResponse
+		err := json.NewDecoder(w.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.NotNil(t, response.Details)
+		assert.Equal(t, runtime.Version(), response.Details["go_version"])
+	})
+
+	t.Run("includes CPU count in details", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		var response HealthResponse
+		err := json.NewDecoder(w.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, response.Details["num_cpu"])
+	})
+
+	t.Run("uptime increases over time", func(t *testing.T) {
+		req1 := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w1 := httptest.NewRecorder()
+		HealthHandler(w1, req1)
+
+		var response1 HealthResponse
+		err := json.NewDecoder(w1.Body).Decode(&response1)
+		require.NoError(t, err)
+
+		time.Sleep(10 * time.Millisecond)
+
+		req2 := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w2 := httptest.NewRecorder()
+		HealthHandler(w2, req2)
+
+		var response2 HealthResponse
+		err = json.NewDecoder(w2.Body).Decode(&response2)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, response1.Uptime, response2.Uptime)
+	})
+
+	t.Run("returns 405 for POST request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+		assert.Contains(t, w.Body.String(), "Method not allowed")
+	})
+
+	t.Run("returns 405 for PUT request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("returns 405 for DELETE request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("returns 405 for PATCH request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPatch, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("response structure matches HealthResponse", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		var response HealthResponse
+		err := json.NewDecoder(w.Body).Decode(&response)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, response.Status)
+		assert.NotEmpty(t, response.Timestamp)
+		assert.NotEmpty(t, response.Service)
+		assert.NotEmpty(t, response.Uptime)
+		assert.NotNil(t, response.Details)
+	})
+
+	t.Run("handles multiple concurrent requests", func(t *testing.T) {
+		numRequests := 10
+		results := make(chan int, numRequests)
+
+		for range numRequests {
+			go func() {
+				req := httptest.NewRequest(http.MethodGet, "/health", nil)
+				w := httptest.NewRecorder()
+				HealthHandler(w, req)
+				results <- w.Code
+			}()
+		}
+
+		for range numRequests {
+			code := <-results
+			assert.Equal(t, http.StatusOK, code)
+		}
+	})
+
+	t.Run("timestamp is recent", func(t *testing.T) {
+		before := time.Now().UTC().Add(-1 * time.Second)
+
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+		HealthHandler(w, req)
+
+		after := time.Now().UTC().Add(1 * time.Second)
+
+		var response HealthResponse
+		err := json.NewDecoder(w.Body).Decode(&response)
+		require.NoError(t, err)
+
+		timestamp, err := time.Parse(time.RFC3339, response.Timestamp)
+		require.NoError(t, err)
+
+		assert.True(t, timestamp.After(before) || timestamp.Equal(before))
+		assert.True(t, timestamp.Before(after) || timestamp.Equal(after))
+	})
+
+	t.Run("handles HEAD request as not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodHead, "/health", nil)
+		w := httptest.NewRecorder()
+
+		HealthHandler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+}
+
+func TestHealthResponse_JSONMarshaling(t *testing.T) {
+	t.Run("marshal and unmarshal preserves data", func(t *testing.T) {
+		original := HealthResponse{
+			Status:    "healthy",
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Service:   "terrascope-api",
+			Uptime:    "1h30m",
+			Details: map[string]string{
+				"go_version": runtime.Version(),
+				"num_cpu":    "8",
+			},
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded HealthResponse
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, original.Status, decoded.Status)
+		assert.Equal(t, original.Timestamp, decoded.Timestamp)
+		assert.Equal(t, original.Service, decoded.Service)
+		assert.Equal(t, original.Uptime, decoded.Uptime)
+		assert.Equal(t, original.Details["go_version"], decoded.Details["go_version"])
+	})
+
+	t.Run("omitempty fields are omitted when empty", func(t *testing.T) {
+		response := HealthResponse{
+			Status:    "healthy",
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Service:   "terrascope-api",
+		}
+
+		data, err := json.Marshal(response)
+		require.NoError(t, err)
+
+		jsonString := string(data)
+		assert.NotContains(t, jsonString, "uptime")
+		assert.NotContains(t, jsonString, "details")
+	})
+}
+
+func TestStartTime(t *testing.T) {
+	t.Run("startTime is initialized", func(t *testing.T) {
+		assert.False(t, startTime.IsZero())
+	})
+
+	t.Run("startTime is in the past", func(t *testing.T) {
+		assert.True(t, startTime.Before(time.Now()))
+	})
+}

--- a/backend/internal/handlers/parse.go
+++ b/backend/internal/handlers/parse.go
@@ -1,0 +1,46 @@
+// Package handlers provides HTTP request handlers for the API endpoints.
+// It defines the routing logic, response formatting, and error handling mechanisms.
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/terrascope/core/internal/parser"
+)
+
+func ParseHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	defer r.Body.Close()
+
+	state, err := parser.ParseTfstate(body)
+	if err != nil {
+		http.Error(w, "Invalid tfstate: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	graph := parser.BuildGraph(state)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	encoder := json.NewEncoder(w)
+	if r.URL.Query().Get("pretty") == "true" {
+		encoder.SetIndent("", "  ")
+	}
+
+	if err := encoder.Encode(graph); err != nil {
+		log.Printf("Error encoding response: %v", err)
+	}
+}

--- a/backend/internal/handlers/parse_test.go
+++ b/backend/internal/handlers/parse_test.go
@@ -1,0 +1,454 @@
+// Package handlers provides HTTP request handlers for the API endpoints.
+// It defines the routing logic, response formatting, and error handling mechanisms.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terrascope/core/internal/models"
+)
+
+func TestParseHandler(t *testing.T) {
+	t.Run("returns 200 OK for valid tfstate", func(t *testing.T) {
+		validTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": []
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(validTfstate))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("returns correct content type", func(t *testing.T) {
+		validTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": []
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(validTfstate))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	})
+
+	t.Run("returns valid graph for empty resources", func(t *testing.T) {
+		validTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": []
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(validTfstate))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		var graph models.Graph
+		err := json.NewDecoder(w.Body).Decode(&graph)
+		require.NoError(t, err)
+
+		assert.Empty(t, graph.Nodes)
+		assert.Empty(t, graph.Edges)
+	})
+
+	t.Run("returns graph with nodes for single resource", func(t *testing.T) {
+		validTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_s3_bucket",
+					"name": "assets",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [
+						{
+							"schema_version": 0,
+							"attributes": {
+								"id": "my-bucket"
+							}
+						}
+					]
+				}
+			]
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(validTfstate))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		var graph models.Graph
+		err := json.NewDecoder(w.Body).Decode(&graph)
+		require.NoError(t, err)
+
+		assert.Len(t, graph.Nodes, 1)
+		assert.Equal(t, "aws_s3_bucket.assets", graph.Nodes[0].ID)
+		assert.Equal(t, "aws_s3_bucket", graph.Nodes[0].Type)
+		assert.Equal(t, "managed", graph.Nodes[0].Mode)
+	})
+
+	t.Run("returns graph with edges for dependencies", func(t *testing.T) {
+		validTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_subnet",
+					"name": "private",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [
+						{
+							"schema_version": 1,
+							"attributes": {
+								"id": "subnet-123"
+							},
+							"dependencies": ["aws_vpc.main"]
+						}
+					]
+				}
+			]
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(validTfstate))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		var graph models.Graph
+		err := json.NewDecoder(w.Body).Decode(&graph)
+		require.NoError(t, err)
+
+		assert.Len(t, graph.Edges, 1)
+		assert.Equal(t, "aws_subnet.private", graph.Edges[0].Source)
+		assert.Equal(t, "aws_vpc.main", graph.Edges[0].Target)
+	})
+
+	t.Run("returns 405 for GET request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/parse", nil)
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+		assert.Contains(t, w.Body.String(), "Method not allowed")
+	})
+
+	t.Run("returns 405 for PUT request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPut, "/parse", nil)
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("returns 405 for DELETE request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/parse", nil)
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("returns 400 for invalid JSON", func(t *testing.T) {
+		invalidJSON := `{invalid json}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(invalidJSON))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "Invalid tfstate")
+	})
+
+	t.Run("returns 400 for empty body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(""))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 400 for missing required fields", func(t *testing.T) {
+		invalidTfstate := `{
+			"version": 4
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(invalidTfstate))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "Invalid tfstate")
+	})
+
+	t.Run("handles large tfstate file", func(t *testing.T) {
+		resources := make([]string, 100)
+		for i := range 100 {
+			resources[i] = fmt.Sprintf(`{
+				"mode": "managed",
+				"type": "aws_s3_bucket",
+				"name": "bucket%d",
+				"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+				"instances": [{
+					"schema_version": 0,
+					"attributes": {"id": "bucket-%d"}
+				}]
+			}`, i, i)
+		}
+
+		largeTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [` + strings.Join(resources, ",") + `]
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(largeTfstate))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var graph models.Graph
+		err := json.NewDecoder(w.Body).Decode(&graph)
+		require.NoError(t, err)
+
+		assert.Len(t, graph.Nodes, 100)
+	})
+
+	t.Run("closes request body", func(t *testing.T) {
+		validTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": []
+		}`
+
+		body := io.NopCloser(strings.NewReader(validTfstate))
+		req := httptest.NewRequest(http.MethodPost, "/parse", body)
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		_, err := body.Read(make([]byte, 1))
+		assert.Error(t, err) // Should error because body is closed
+	})
+
+	t.Run("handles nil body gracefully", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/parse", nil)
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.True(t, w.Code == http.StatusBadRequest || w.Code == http.StatusInternalServerError)
+	})
+
+	t.Run("handles complex tfstate with modules", func(t *testing.T) {
+		complexTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_vpc",
+					"name": "main",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [{
+						"schema_version": 1,
+						"attributes": {"id": "vpc-123"}
+					}]
+				},
+				{
+					"mode": "managed",
+					"type": "aws_instance",
+					"name": "web",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"module": "module.app",
+					"instances": [{
+						"schema_version": 1,
+						"attributes": {"id": "i-123"},
+						"dependencies": ["aws_vpc.main"]
+					}]
+				}
+			]
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(complexTfstate))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var graph models.Graph
+		err := json.NewDecoder(w.Body).Decode(&graph)
+		require.NoError(t, err)
+
+		assert.Len(t, graph.Nodes, 2)
+		assert.Len(t, graph.Edges, 1)
+
+		// Find the module node
+		var moduleNode *models.Node
+		for i, node := range graph.Nodes {
+			if node.Module != "" {
+				moduleNode = &graph.Nodes[i]
+				break
+			}
+		}
+		require.NotNil(t, moduleNode)
+		assert.Equal(t, "module.app", moduleNode.Module)
+	})
+
+	t.Run("handles concurrent requests", func(t *testing.T) {
+		validTfstate := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": []
+		}`
+
+		numRequests := 10
+		results := make(chan int, numRequests)
+
+		for range numRequests {
+			go func() {
+				req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(validTfstate))
+				w := httptest.NewRecorder()
+				ParseHandler(w, req)
+				results <- w.Code
+			}()
+		}
+
+		for range numRequests {
+			code := <-results
+			assert.Equal(t, http.StatusOK, code)
+		}
+	})
+
+	t.Run("handles binary data gracefully", func(t *testing.T) {
+		binaryData := []byte{0x00, 0x01, 0x02, 0xFF, 0xFE}
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", bytes.NewReader(binaryData))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "Invalid tfstate")
+	})
+
+	t.Run("preserves resource metadata", func(t *testing.T) {
+		tfstateWithMetadata := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_instance",
+					"name": "web",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [{
+						"schema_version": 1,
+						"attributes": {
+							"id": "i-1234567890",
+							"name": "web-server",
+							"tags": {
+								"Environment": "production",
+								"Team": "platform"
+							}
+						}
+					}]
+				}
+			]
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(tfstateWithMetadata))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		var graph models.Graph
+		err := json.NewDecoder(w.Body).Decode(&graph)
+		require.NoError(t, err)
+
+		assert.Len(t, graph.Nodes, 1)
+		assert.NotNil(t, graph.Nodes[0].Metadata)
+		assert.Equal(t, "i-1234567890", graph.Nodes[0].Metadata["id"])
+		assert.Equal(t, "web-server", graph.Nodes[0].Metadata["name"])
+	})
+
+	t.Run("handles data sources", func(t *testing.T) {
+		tfstateWithDataSource := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "data",
+					"type": "aws_ami",
+					"name": "ubuntu",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [{
+						"schema_version": 0,
+						"attributes": {"id": "ami-123456"}
+					}]
+				}
+			]
+		}`
+
+		req := httptest.NewRequest(http.MethodPost, "/parse", strings.NewReader(tfstateWithDataSource))
+		w := httptest.NewRecorder()
+
+		ParseHandler(w, req)
+
+		var graph models.Graph
+		err := json.NewDecoder(w.Body).Decode(&graph)
+		require.NoError(t, err)
+
+		assert.Len(t, graph.Nodes, 1)
+		assert.Equal(t, "data", graph.Nodes[0].Mode)
+	})
+}

--- a/backend/internal/models/graph.go
+++ b/backend/internal/models/graph.go
@@ -1,0 +1,31 @@
+// Package models defines the core data structures and database interaction logic.
+// It includes entity definitions and methods for persistence and validation.
+package models
+
+type Graph struct {
+	Nodes []Node `json:"nodes"`
+	Edges []Edge `json:"edges"`
+	Stats *Stats `json:"stats,omitempty"`
+}
+
+type Node struct {
+	ID       string         `json:"id"`
+	Type     string         `json:"type"`
+	Mode     string         `json:"mode"`
+	Provider string         `json:"provider"`
+	Module   string         `json:"module,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+type Edge struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Type   string `json:"type"`
+}
+
+type Stats struct {
+	TotalNodes      int            `json:"total_nodes"`
+	TotalEdges      int            `json:"total_edges"`
+	ResourcesByType map[string]int `json:"resources_by_type,omitempty"`
+	ResourcesByMode map[string]int `json:"resources_by_mode,omitempty"`
+}

--- a/backend/internal/models/graph_test.go
+++ b/backend/internal/models/graph_test.go
@@ -1,0 +1,501 @@
+// Package models defines the core data structures and database interaction logic.
+// It includes entity definitions and methods for persistence and validation.
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphUnmarshal(t *testing.T) {
+	t.Run("empty graph", func(t *testing.T) {
+		jsonData := `{
+			"nodes": [],
+			"edges": []
+		}`
+
+		var graph Graph
+		err := json.Unmarshal([]byte(jsonData), &graph)
+
+		require.NoError(t, err)
+		assert.Empty(t, graph.Nodes)
+		assert.Empty(t, graph.Edges)
+	})
+
+	t.Run("graph with nodes and edges", func(t *testing.T) {
+		jsonData := `{
+			"nodes": [
+				{
+					"id": "aws_vpc.main",
+					"type": "aws_vpc",
+					"mode": "managed",
+					"provider": "aws"
+				},
+				{
+					"id": "aws_subnet.private",
+					"type": "aws_subnet",
+					"mode": "managed",
+					"provider": "aws"
+				}
+			],
+			"edges": [
+				{
+					"source": "aws_subnet.private",
+					"target": "aws_vpc.main",
+					"type": "implicit"
+				}
+			]
+		}`
+
+		var graph Graph
+		err := json.Unmarshal([]byte(jsonData), &graph)
+
+		require.NoError(t, err)
+		assert.Len(t, graph.Nodes, 2)
+		assert.Len(t, graph.Edges, 1)
+		assert.Equal(t, "aws_vpc.main", graph.Nodes[0].ID)
+		assert.Equal(t, "aws_subnet.private", graph.Edges[0].Source)
+	})
+
+	t.Run("graph with stats", func(t *testing.T) {
+		jsonData := `{
+			"nodes": [],
+			"edges": [],
+			"stats": {
+				"total_nodes": 10,
+				"total_edges": 5,
+				"resources_by_type": {
+					"aws_vpc": 1,
+					"aws_subnet": 3
+				},
+				"resources_by_mode": {
+					"managed": 8,
+					"data": 2
+				}
+			}
+		}`
+
+		var graph Graph
+		err := json.Unmarshal([]byte(jsonData), &graph)
+
+		require.NoError(t, err)
+		assert.Equal(t, 10, graph.Stats.TotalNodes)
+		assert.Equal(t, 5, graph.Stats.TotalEdges)
+		assert.Equal(t, 1, graph.Stats.ResourcesByType["aws_vpc"])
+		assert.Equal(t, 8, graph.Stats.ResourcesByMode["managed"])
+	})
+}
+
+func TestGraphMarshal(t *testing.T) {
+	t.Run("marshal empty graph", func(t *testing.T) {
+		graph := Graph{
+			Nodes: []Node{},
+			Edges: []Edge{},
+		}
+
+		data, err := json.Marshal(graph)
+		require.NoError(t, err)
+
+		var decoded Graph
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Empty(t, decoded.Nodes)
+		assert.Empty(t, decoded.Edges)
+	})
+
+	t.Run("marshal graph with data", func(t *testing.T) {
+		graph := Graph{
+			Nodes: []Node{
+				{
+					ID:       "aws_vpc.main",
+					Type:     "aws_vpc",
+					Mode:     "managed",
+					Provider: "aws",
+				},
+			},
+			Edges: []Edge{
+				{
+					Source: "aws_subnet.private",
+					Target: "aws_vpc.main",
+					Type:   "implicit",
+				},
+			},
+			Stats: &Stats{
+				TotalNodes: 1,
+				TotalEdges: 1,
+			},
+		}
+
+		data, err := json.Marshal(graph)
+		require.NoError(t, err)
+
+		var decoded Graph
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Len(t, decoded.Nodes, 1)
+		assert.Len(t, decoded.Edges, 1)
+		assert.Equal(t, 1, decoded.Stats.TotalNodes)
+	})
+
+	t.Run("omitempty stats when not set", func(t *testing.T) {
+		graph := Graph{
+			Nodes: []Node{},
+			Edges: []Edge{},
+		}
+
+		data, err := json.Marshal(graph)
+		require.NoError(t, err)
+
+		jsonString := string(data)
+		assert.NotContains(t, jsonString, "stats")
+	})
+}
+
+func TestNodeUnmarshal(t *testing.T) {
+	t.Run("node with all required fields", func(t *testing.T) {
+		jsonData := `{
+			"id": "aws_s3_bucket.assets",
+			"type": "aws_s3_bucket",
+			"mode": "managed",
+			"provider": "aws"
+		}`
+
+		var node Node
+		err := json.Unmarshal([]byte(jsonData), &node)
+
+		require.NoError(t, err)
+		assert.Equal(t, "aws_s3_bucket.assets", node.ID)
+		assert.Equal(t, "aws_s3_bucket", node.Type)
+		assert.Equal(t, "managed", node.Mode)
+		assert.Equal(t, "aws", node.Provider)
+	})
+
+	t.Run("node with module", func(t *testing.T) {
+		jsonData := `{
+			"id": "module.app.aws_instance.web",
+			"type": "aws_instance",
+			"mode": "managed",
+			"provider": "aws",
+			"module": "module.app"
+		}`
+
+		var node Node
+		err := json.Unmarshal([]byte(jsonData), &node)
+
+		require.NoError(t, err)
+		assert.Equal(t, "module.app", node.Module)
+	})
+
+	t.Run("node with metadata", func(t *testing.T) {
+		jsonData := `{
+			"id": "aws_instance.web",
+			"type": "aws_instance",
+			"mode": "managed",
+			"provider": "aws",
+			"metadata": {
+				"id": "i-1234567890",
+				"name": "web-server",
+				"tags": {
+					"Environment": "production"
+				}
+			}
+		}`
+
+		var node Node
+		err := json.Unmarshal([]byte(jsonData), &node)
+
+		require.NoError(t, err)
+		assert.NotNil(t, node.Metadata)
+		assert.Equal(t, "i-1234567890", node.Metadata["id"])
+		assert.Equal(t, "web-server", node.Metadata["name"])
+
+		tags, ok := node.Metadata["tags"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "production", tags["Environment"])
+	})
+
+	t.Run("data source node", func(t *testing.T) {
+		jsonData := `{
+			"id": "data.aws_ami.ubuntu",
+			"type": "aws_ami",
+			"mode": "data",
+			"provider": "aws"
+		}`
+
+		var node Node
+		err := json.Unmarshal([]byte(jsonData), &node)
+
+		require.NoError(t, err)
+		assert.Equal(t, "data", node.Mode)
+	})
+}
+
+func TestNodeMarshal(t *testing.T) {
+	t.Run("marshal node without optional fields", func(t *testing.T) {
+		node := Node{
+			ID:       "aws_vpc.main",
+			Type:     "aws_vpc",
+			Mode:     "managed",
+			Provider: "aws",
+		}
+
+		data, err := json.Marshal(node)
+		require.NoError(t, err)
+
+		jsonString := string(data)
+		assert.NotContains(t, jsonString, "module")
+		assert.NotContains(t, jsonString, "metadata")
+	})
+
+	t.Run("marshal node with all fields", func(t *testing.T) {
+		node := Node{
+			ID:       "module.app.aws_instance.web",
+			Type:     "aws_instance",
+			Mode:     "managed",
+			Provider: "aws",
+			Module:   "module.app",
+			Metadata: map[string]any{
+				"id":   "i-123",
+				"name": "web-server",
+			},
+		}
+
+		data, err := json.Marshal(node)
+		require.NoError(t, err)
+
+		var decoded Node
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, node.ID, decoded.ID)
+		assert.Equal(t, node.Module, decoded.Module)
+		assert.Equal(t, "i-123", decoded.Metadata["id"])
+	})
+}
+
+func TestEdgeUnmarshal(t *testing.T) {
+	t.Run("implicit dependency edge", func(t *testing.T) {
+		jsonData := `{
+			"source": "aws_subnet.private",
+			"target": "aws_vpc.main",
+			"type": "implicit"
+		}`
+
+		var edge Edge
+		err := json.Unmarshal([]byte(jsonData), &edge)
+
+		require.NoError(t, err)
+		assert.Equal(t, "aws_subnet.private", edge.Source)
+		assert.Equal(t, "aws_vpc.main", edge.Target)
+		assert.Equal(t, "implicit", edge.Type)
+	})
+
+	t.Run("explicit depends_on edge", func(t *testing.T) {
+		jsonData := `{
+			"source": "aws_instance.web",
+			"target": "aws_security_group.web",
+			"type": "depends_on"
+		}`
+
+		var edge Edge
+		err := json.Unmarshal([]byte(jsonData), &edge)
+
+		require.NoError(t, err)
+		assert.Equal(t, "depends_on", edge.Type)
+	})
+}
+
+func TestEdgeMarshal(t *testing.T) {
+	t.Run("marshal edge", func(t *testing.T) {
+		edge := Edge{
+			Source: "aws_subnet.private",
+			Target: "aws_vpc.main",
+			Type:   "implicit",
+		}
+
+		data, err := json.Marshal(edge)
+		require.NoError(t, err)
+
+		var decoded Edge
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, edge.Source, decoded.Source)
+		assert.Equal(t, edge.Target, decoded.Target)
+		assert.Equal(t, edge.Type, decoded.Type)
+	})
+}
+
+func TestStatsUnmarshal(t *testing.T) {
+	t.Run("stats with all fields", func(t *testing.T) {
+		jsonData := `{
+			"total_nodes": 15,
+			"total_edges": 12,
+			"resources_by_type": {
+				"aws_vpc": 1,
+				"aws_subnet": 3,
+				"aws_instance": 5
+			},
+			"resources_by_mode": {
+				"managed": 13,
+				"data": 2
+			}
+		}`
+
+		var stats Stats
+		err := json.Unmarshal([]byte(jsonData), &stats)
+
+		require.NoError(t, err)
+		assert.Equal(t, 15, stats.TotalNodes)
+		assert.Equal(t, 12, stats.TotalEdges)
+		assert.Len(t, stats.ResourcesByType, 3)
+		assert.Len(t, stats.ResourcesByMode, 2)
+		assert.Equal(t, 1, stats.ResourcesByType["aws_vpc"])
+		assert.Equal(t, 13, stats.ResourcesByMode["managed"])
+	})
+
+	t.Run("stats with minimal fields", func(t *testing.T) {
+		jsonData := `{
+			"total_nodes": 5,
+			"total_edges": 3
+		}`
+
+		var stats Stats
+		err := json.Unmarshal([]byte(jsonData), &stats)
+
+		require.NoError(t, err)
+		assert.Equal(t, 5, stats.TotalNodes)
+		assert.Equal(t, 3, stats.TotalEdges)
+		assert.Nil(t, stats.ResourcesByType)
+		assert.Nil(t, stats.ResourcesByMode)
+	})
+}
+
+func TestStatsMarshal(t *testing.T) {
+	t.Run("marshal stats with all fields", func(t *testing.T) {
+		stats := Stats{
+			TotalNodes: 10,
+			TotalEdges: 8,
+			ResourcesByType: map[string]int{
+				"aws_vpc":    1,
+				"aws_subnet": 3,
+			},
+			ResourcesByMode: map[string]int{
+				"managed": 8,
+				"data":    2,
+			},
+		}
+
+		data, err := json.Marshal(stats)
+		require.NoError(t, err)
+
+		var decoded Stats
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, stats.TotalNodes, decoded.TotalNodes)
+		assert.Equal(t, stats.TotalEdges, decoded.TotalEdges)
+		assert.Equal(t, stats.ResourcesByType["aws_vpc"], decoded.ResourcesByType["aws_vpc"])
+		assert.Equal(t, stats.ResourcesByMode["managed"], decoded.ResourcesByMode["managed"])
+	})
+
+	t.Run("omitempty maps when nil", func(t *testing.T) {
+		stats := Stats{
+			TotalNodes: 5,
+			TotalEdges: 3,
+		}
+
+		data, err := json.Marshal(stats)
+		require.NoError(t, err)
+
+		jsonString := string(data)
+		assert.NotContains(t, jsonString, "resources_by_type")
+		assert.NotContains(t, jsonString, "resources_by_mode")
+	})
+}
+
+func TestCompleteGraphRoundTrip(t *testing.T) {
+	t.Run("full graph serialization roundtrip", func(t *testing.T) {
+		original := Graph{
+			Nodes: []Node{
+				{
+					ID:       "aws_vpc.main",
+					Type:     "aws_vpc",
+					Mode:     "managed",
+					Provider: "aws",
+					Metadata: map[string]any{
+						"id":   "vpc-123",
+						"cidr": "10.0.0.0/16",
+					},
+				},
+				{
+					ID:       "module.app.aws_instance.web",
+					Type:     "aws_instance",
+					Mode:     "managed",
+					Provider: "aws",
+					Module:   "module.app",
+					Metadata: map[string]any{
+						"id": "i-123",
+					},
+				},
+				{
+					ID:       "data.aws_ami.ubuntu",
+					Type:     "aws_ami",
+					Mode:     "data",
+					Provider: "aws",
+				},
+			},
+			Edges: []Edge{
+				{
+					Source: "module.app.aws_instance.web",
+					Target: "aws_vpc.main",
+					Type:   "implicit",
+				},
+				{
+					Source: "module.app.aws_instance.web",
+					Target: "data.aws_ami.ubuntu",
+					Type:   "implicit",
+				},
+			},
+			Stats: &Stats{
+				TotalNodes: 3,
+				TotalEdges: 2,
+				ResourcesByType: map[string]int{
+					"aws_vpc":      1,
+					"aws_instance": 1,
+					"aws_ami":      1,
+				},
+				ResourcesByMode: map[string]int{
+					"managed": 2,
+					"data":    1,
+				},
+			},
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded Graph
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Len(t, decoded.Nodes, 3)
+		assert.Len(t, decoded.Edges, 2)
+		assert.Equal(t, original.Stats.TotalNodes, decoded.Stats.TotalNodes)
+		assert.Equal(t, original.Stats.TotalEdges, decoded.Stats.TotalEdges)
+
+		assert.Equal(t, "aws_vpc.main", decoded.Nodes[0].ID)
+		assert.Equal(t, "module.app", decoded.Nodes[1].Module)
+		assert.Equal(t, "data", decoded.Nodes[2].Mode)
+
+		assert.Equal(t, "vpc-123", decoded.Nodes[0].Metadata["id"])
+
+		assert.Equal(t, "module.app.aws_instance.web", decoded.Edges[0].Source)
+		assert.Equal(t, "implicit", decoded.Edges[0].Type)
+	})
+}

--- a/backend/internal/models/tfstate.go
+++ b/backend/internal/models/tfstate.go
@@ -1,0 +1,37 @@
+// Package models defines the core data structures and database interaction logic.
+// It includes entity definitions and methods for persistence and validation.
+package models
+
+type TerraformState struct {
+	Version          int               `json:"version"`
+	TerraformVersion string            `json:"terraform_version"`
+	Serial           int               `json:"serial"`
+	Lineage          string            `json:"lineage"`
+	Outputs          map[string]Output `json:"outputs,omitempty"`
+	Resources        []ResourceState   `json:"resources"`
+}
+
+type Output struct {
+	Value     any  `json:"value"`
+	Type      any  `json:"type"`
+	Sensitive bool `json:"sensitive,omitempty"`
+}
+
+type ResourceState struct {
+	Mode      string             `json:"mode"`
+	Type      string             `json:"type"`
+	Name      string             `json:"name"`
+	Provider  string             `json:"provider"`
+	Module    string             `json:"module,omitempty"`
+	Instances []ResourceInstance `json:"instances"`
+	DependsOn []string           `json:"depends_on,omitempty"`
+}
+
+type ResourceInstance struct {
+	SchemaVersion  int               `json:"schema_version"`
+	Attributes     map[string]any    `json:"attributes"`
+	AttributesFlat map[string]string `json:"attributes_flat,omitempty"`
+	Private        string            `json:"private,omitempty"`
+	Dependencies   []string          `json:"dependencies,omitempty"`
+	IndexKey       any               `json:"index_key,omitempty"`
+}

--- a/backend/internal/models/tfstate_test.go
+++ b/backend/internal/models/tfstate_test.go
@@ -1,0 +1,502 @@
+// Package models defines the core data structures and database interaction logic.
+// It includes entity definitions and methods for persistence and validation.
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerraformStateUnmarshal(t *testing.T) {
+	t.Run("minimal valid state", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": []
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.Equal(t, 4, state.Version)
+		assert.Equal(t, "1.5.0", state.TerraformVersion)
+		assert.Equal(t, 1, state.Serial)
+		assert.Equal(t, "abc-123", state.Lineage)
+		assert.Empty(t, state.Resources)
+	})
+
+	t.Run("state with outputs", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"outputs": {
+				"bucket_name": {
+					"value": "my-bucket",
+					"type": "string"
+				},
+				"instance_count": {
+					"value": 3,
+					"type": "number",
+					"sensitive": false
+				}
+			},
+			"resources": []
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.Len(t, state.Outputs, 2)
+		assert.Equal(t, "my-bucket", state.Outputs["bucket_name"].Value)
+		assert.Equal(t, float64(3), state.Outputs["instance_count"].Value)
+		assert.False(t, state.Outputs["instance_count"].Sensitive)
+	})
+
+	t.Run("state with sensitive output", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"outputs": {
+				"db_password": {
+					"value": "secret",
+					"type": "string",
+					"sensitive": true
+				}
+			},
+			"resources": []
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.True(t, state.Outputs["db_password"].Sensitive)
+	})
+
+	t.Run("state with managed resource", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_s3_bucket",
+					"name": "assets",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [
+						{
+							"schema_version": 0,
+							"attributes": {
+								"id": "my-bucket",
+								"bucket": "my-bucket",
+								"arn": "arn:aws:s3:::my-bucket"
+							}
+						}
+					]
+				}
+			]
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.Len(t, state.Resources, 1)
+
+		res := state.Resources[0]
+		assert.Equal(t, "managed", res.Mode)
+		assert.Equal(t, "aws_s3_bucket", res.Type)
+		assert.Equal(t, "assets", res.Name)
+		assert.Equal(t, "provider[\"registry.terraform.io/hashicorp/aws\"]", res.Provider)
+		assert.Len(t, res.Instances, 1)
+		assert.Equal(t, "my-bucket", res.Instances[0].Attributes["id"])
+	})
+
+	t.Run("state with data source", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "data",
+					"type": "aws_ami",
+					"name": "ubuntu",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [
+						{
+							"schema_version": 0,
+							"attributes": {
+								"id": "ami-123456",
+								"name": "ubuntu-20.04"
+							}
+						}
+					]
+				}
+			]
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.Equal(t, "data", state.Resources[0].Mode)
+		assert.Equal(t, "aws_ami", state.Resources[0].Type)
+	})
+
+	t.Run("resource with module", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_instance",
+					"name": "web",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"module": "module.app",
+					"instances": [
+						{
+							"schema_version": 1,
+							"attributes": {
+								"id": "i-1234567890"
+							}
+						}
+					]
+				}
+			]
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.Equal(t, "module.app", state.Resources[0].Module)
+	})
+
+	t.Run("resource with depends_on", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_instance",
+					"name": "web",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"depends_on": [
+						"aws_vpc.main",
+						"aws_security_group.web"
+					],
+					"instances": [
+						{
+							"schema_version": 1,
+							"attributes": {
+								"id": "i-123"
+							}
+						}
+					]
+				}
+			]
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.Len(t, state.Resources[0].DependsOn, 2)
+		assert.Contains(t, state.Resources[0].DependsOn, "aws_vpc.main")
+		assert.Contains(t, state.Resources[0].DependsOn, "aws_security_group.web")
+	})
+
+	t.Run("resource with multiple instances", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_subnet",
+					"name": "private",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [
+						{
+							"schema_version": 1,
+							"attributes": {
+								"id": "subnet-1"
+							},
+							"index_key": 0
+						},
+						{
+							"schema_version": 1,
+							"attributes": {
+								"id": "subnet-2"
+							},
+							"index_key": 1
+						}
+					]
+				}
+			]
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.Len(t, state.Resources[0].Instances, 2)
+		assert.Equal(t, float64(0), state.Resources[0].Instances[0].IndexKey)
+		assert.Equal(t, float64(1), state.Resources[0].Instances[1].IndexKey)
+	})
+
+	t.Run("instance with dependencies", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_subnet",
+					"name": "private",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [
+						{
+							"schema_version": 1,
+							"attributes": {
+								"id": "subnet-1"
+							},
+							"dependencies": [
+								"aws_vpc.main"
+							]
+						}
+					]
+				}
+			]
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.Len(t, state.Resources[0].Instances[0].Dependencies, 1)
+		assert.Equal(t, "aws_vpc.main", state.Resources[0].Instances[0].Dependencies[0])
+	})
+
+	t.Run("instance with private field", func(t *testing.T) {
+		jsonData := `{
+			"version": 4,
+			"terraform_version": "1.5.0",
+			"serial": 1,
+			"lineage": "abc-123",
+			"resources": [
+				{
+					"mode": "managed",
+					"type": "aws_instance",
+					"name": "web",
+					"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					"instances": [
+						{
+							"schema_version": 1,
+							"attributes": {
+								"id": "i-123"
+							},
+							"private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+						}
+					]
+				}
+			]
+		}`
+
+		var state TerraformState
+		err := json.Unmarshal([]byte(jsonData), &state)
+
+		require.NoError(t, err)
+		assert.Equal(t, "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==", state.Resources[0].Instances[0].Private)
+	})
+}
+
+func TestTerraformStateMarshal(t *testing.T) {
+	t.Run("marshal minimal state", func(t *testing.T) {
+		state := TerraformState{
+			Version:          4,
+			TerraformVersion: "1.5.0",
+			Serial:           1,
+			Lineage:          "abc-123",
+			Resources:        []ResourceState{},
+		}
+
+		data, err := json.Marshal(state)
+		require.NoError(t, err)
+
+		var decoded TerraformState
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, state.Version, decoded.Version)
+		assert.Equal(t, state.TerraformVersion, decoded.TerraformVersion)
+		assert.Equal(t, state.Serial, decoded.Serial)
+		assert.Equal(t, state.Lineage, decoded.Lineage)
+	})
+
+	t.Run("marshal state with resources", func(t *testing.T) {
+		state := TerraformState{
+			Version:          4,
+			TerraformVersion: "1.5.0",
+			Serial:           1,
+			Lineage:          "abc-123",
+			Resources: []ResourceState{
+				{
+					Mode:     "managed",
+					Type:     "aws_s3_bucket",
+					Name:     "assets",
+					Provider: "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					Instances: []ResourceInstance{
+						{
+							SchemaVersion: 0,
+							Attributes: map[string]any{
+								"id":     "my-bucket",
+								"bucket": "my-bucket",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		data, err := json.Marshal(state)
+		require.NoError(t, err)
+
+		var decoded TerraformState
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Len(t, decoded.Resources, 1)
+		assert.Equal(t, "aws_s3_bucket", decoded.Resources[0].Type)
+		assert.Equal(t, "my-bucket", decoded.Resources[0].Instances[0].Attributes["id"])
+	})
+
+	t.Run("omitempty fields are omitted when empty", func(t *testing.T) {
+		state := TerraformState{
+			Version:          4,
+			TerraformVersion: "1.5.0",
+			Serial:           1,
+			Lineage:          "abc-123",
+			Resources:        []ResourceState{},
+		}
+
+		data, err := json.Marshal(state)
+		require.NoError(t, err)
+
+		jsonString := string(data)
+		assert.NotContains(t, jsonString, "outputs")
+	})
+
+	t.Run("omitempty fields are included when present", func(t *testing.T) {
+		state := TerraformState{
+			Version:          4,
+			TerraformVersion: "1.5.0",
+			Serial:           1,
+			Lineage:          "abc-123",
+			Outputs: map[string]Output{
+				"bucket_name": {
+					Value: "my-bucket",
+					Type:  "string",
+				},
+			},
+			Resources: []ResourceState{},
+		}
+
+		data, err := json.Marshal(state)
+		require.NoError(t, err)
+
+		jsonString := string(data)
+		assert.Contains(t, jsonString, "outputs")
+		assert.Contains(t, jsonString, "bucket_name")
+	})
+}
+
+func TestResourceStateFields(t *testing.T) {
+	t.Run("all fields present", func(t *testing.T) {
+		jsonData := `{
+			"mode": "managed",
+			"type": "aws_instance",
+			"name": "web",
+			"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+			"module": "module.app",
+			"depends_on": ["aws_vpc.main"],
+			"instances": [
+				{
+					"schema_version": 1,
+					"attributes": {"id": "i-123"},
+					"dependencies": ["aws_subnet.private"],
+					"index_key": 0,
+					"private": "base64string"
+				}
+			]
+		}`
+
+		var res ResourceState
+		err := json.Unmarshal([]byte(jsonData), &res)
+
+		require.NoError(t, err)
+		assert.Equal(t, "managed", res.Mode)
+		assert.Equal(t, "aws_instance", res.Type)
+		assert.Equal(t, "web", res.Name)
+		assert.Equal(t, "module.app", res.Module)
+		assert.Len(t, res.DependsOn, 1)
+		assert.Len(t, res.Instances, 1)
+		assert.Len(t, res.Instances[0].Dependencies, 1)
+	})
+}
+
+func TestOutputFields(t *testing.T) {
+	t.Run("output with all fields", func(t *testing.T) {
+		jsonData := `{
+			"value": "sensitive-data",
+			"type": "string",
+			"sensitive": true
+		}`
+
+		var output Output
+		err := json.Unmarshal([]byte(jsonData), &output)
+
+		require.NoError(t, err)
+		assert.Equal(t, "sensitive-data", output.Value)
+		assert.Equal(t, "string", output.Type)
+		assert.True(t, output.Sensitive)
+	})
+
+	t.Run("output without sensitive field", func(t *testing.T) {
+		jsonData := `{
+			"value": "public-data",
+			"type": "string"
+		}`
+
+		var output Output
+		err := json.Unmarshal([]byte(jsonData), &output)
+
+		require.NoError(t, err)
+		assert.False(t, output.Sensitive)
+	})
+}

--- a/backend/internal/parser/graph.go
+++ b/backend/internal/parser/graph.go
@@ -58,20 +58,22 @@ func buildNodeID(res models.ResourceState, instance models.ResourceInstance, ins
 		parts = append(parts, res.Module)
 	}
 
-	parts = append(parts, res.Type, res.Name)
+	name := res.Name
 
 	if len(res.Instances) > 1 {
 		key := instance.IndexKey
 		if key != nil {
 			val := reflect.ValueOf(key)
-			if val.Kind() == reflect.Ptr && !val.IsNil() {
+			if val.Kind() == reflect.Pointer && !val.IsNil() {
 				val = val.Elem()
 			}
-			parts = append(parts, fmt.Sprintf("[%v]", val.Interface()))
+			name = fmt.Sprintf("%s[%v]", name, val.Interface())
 		} else {
-			parts = append(parts, fmt.Sprintf("[%d]", instanceIndex))
+			name = fmt.Sprintf("%s[%d]", name, instanceIndex)
 		}
 	}
+
+	parts = append(parts, res.Type, name)
 
 	return strings.Join(parts, ".")
 }

--- a/backend/internal/parser/graph.go
+++ b/backend/internal/parser/graph.go
@@ -1,0 +1,133 @@
+// Package parser provides utilities for parsing and transforming input data.
+// It handles data normalization, validation, and conversion between formats.
+package parser
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/terrascope/core/internal/models"
+)
+
+func BuildGraph(state *models.TerraformState) *models.Graph {
+	graph := &models.Graph{
+		Nodes: []models.Node{},
+		Edges: []models.Edge{},
+	}
+	nodeMap := make(map[string]bool)
+
+	for _, res := range state.Resources {
+		for i, instance := range res.Instances {
+			nodeID := buildNodeID(res, instance, i)
+
+			if nodeMap[nodeID] {
+				continue
+			}
+
+			node := models.Node{
+				ID:       nodeID,
+				Type:     res.Type,
+				Mode:     res.Mode,
+				Provider: extractProviderName(res.Provider),
+				Module:   res.Module,
+				Metadata: buildMetadata(res, instance),
+			}
+
+			graph.Nodes = append(graph.Nodes, node)
+			nodeMap[nodeID] = true
+			deps := collectDependencies(res.DependsOn, instance.Dependencies)
+
+			for target, edgeType := range deps {
+				graph.Edges = append(graph.Edges, models.Edge{
+					Source: nodeID,
+					Target: target,
+					Type:   edgeType,
+				})
+			}
+		}
+	}
+
+	return graph
+}
+
+func buildNodeID(res models.ResourceState, instance models.ResourceInstance, instanceIndex int) string {
+	parts := []string{}
+
+	if res.Module != "" {
+		parts = append(parts, res.Module)
+	}
+
+	parts = append(parts, res.Type, res.Name)
+
+	if len(res.Instances) > 1 {
+		key := instance.IndexKey
+		if key != nil {
+			val := reflect.ValueOf(key)
+			if val.Kind() == reflect.Ptr && !val.IsNil() {
+				val = val.Elem()
+			}
+			parts = append(parts, fmt.Sprintf("[%v]", val.Interface()))
+		} else {
+			parts = append(parts, fmt.Sprintf("[%d]", instanceIndex))
+		}
+	}
+
+	return strings.Join(parts, ".")
+}
+
+func extractProviderName(providerString string) string {
+	providerString = strings.TrimPrefix(providerString, "provider[\"")
+	providerString = strings.TrimSuffix(providerString, "\"]")
+
+	parts := strings.Split(providerString, "/")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+
+	return providerString
+}
+
+func buildMetadata(res models.ResourceState, instance models.ResourceInstance) map[string]any {
+	metadata := map[string]any{
+		"mode": res.Mode,
+	}
+
+	if id, ok := instance.Attributes["id"]; ok {
+		metadata["id"] = id
+	}
+
+	if name, ok := instance.Attributes["name"]; ok {
+		metadata["name"] = name
+	}
+
+	if arn, ok := instance.Attributes["arn"]; ok {
+		metadata["arn"] = arn
+	}
+
+	if tags, ok := instance.Attributes["tags"].(map[string]any); ok {
+		metadata["tags"] = tags
+	}
+
+	if instance.IndexKey != nil {
+		metadata["index_key"] = instance.IndexKey
+	}
+
+	return metadata
+}
+
+func collectDependencies(explicit, implicit []string) map[string]string {
+	deps := make(map[string]string)
+
+	for _, dep := range explicit {
+		deps[dep] = "depends_on"
+	}
+
+	for _, dep := range implicit {
+		if _, exists := deps[dep]; !exists {
+			deps[dep] = "implicit"
+		}
+	}
+
+	return deps
+}

--- a/backend/internal/parser/graph_test.go
+++ b/backend/internal/parser/graph_test.go
@@ -105,8 +105,8 @@ func TestBuildGraph(t *testing.T) {
 		graph := BuildGraph(state)
 
 		assert.Len(t, graph.Nodes, 2)
-		assert.Equal(t, "aws_subnet.private.[0]", graph.Nodes[0].ID)
-		assert.Equal(t, "aws_subnet.private.[1]", graph.Nodes[1].ID)
+		assert.Equal(t, "aws_subnet.private[0]", graph.Nodes[0].ID)
+		assert.Equal(t, "aws_subnet.private[1]", graph.Nodes[1].ID)
 	})
 
 	t.Run("duplicate nodes are not added", func(t *testing.T) {
@@ -286,8 +286,8 @@ func TestBuildNodeID(t *testing.T) {
 		id0 := buildNodeID(res, res.Instances[0], 0)
 		id1 := buildNodeID(res, res.Instances[1], 1)
 
-		assert.Equal(t, "aws_subnet.private.[0]", id0)
-		assert.Equal(t, "aws_subnet.private.[1]", id1)
+		assert.Equal(t, "aws_subnet.private[0]", id0)
+		assert.Equal(t, "aws_subnet.private[1]", id1)
 	})
 
 	t.Run("single instance does not add index", func(t *testing.T) {
@@ -317,8 +317,8 @@ func TestBuildNodeID(t *testing.T) {
 		id0 := buildNodeID(res, res.Instances[0], 0)
 		id1 := buildNodeID(res, res.Instances[1], 1)
 
-		assert.Equal(t, "aws_security_group.sg.[frontend]", id0)
-		assert.Equal(t, "aws_security_group.sg.[backend]", id1)
+		assert.Equal(t, "aws_security_group.sg[frontend]", id0)
+		assert.Equal(t, "aws_security_group.sg[backend]", id1)
 	})
 }
 

--- a/backend/internal/parser/graph_test.go
+++ b/backend/internal/parser/graph_test.go
@@ -1,0 +1,499 @@
+// Package parser provides utilities for parsing and transforming input data.
+// It handles data normalization, validation, and conversion between formats.
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/terrascope/core/internal/models"
+)
+
+func TestBuildGraph(t *testing.T) {
+	t.Run("empty state returns empty graph", func(t *testing.T) {
+		state := &models.TerraformState{
+			Resources: []models.ResourceState{},
+		}
+
+		graph := BuildGraph(state)
+
+		assert.NotNil(t, graph)
+		assert.Empty(t, graph.Nodes)
+		assert.Empty(t, graph.Edges)
+	})
+
+	t.Run("single resource creates single node", func(t *testing.T) {
+		state := &models.TerraformState{
+			Resources: []models.ResourceState{
+				{
+					Type:     "aws_s3_bucket",
+					Name:     "assets",
+					Mode:     "managed",
+					Provider: "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					Module:   "",
+					Instances: []models.ResourceInstance{
+						{
+							Attributes: map[string]any{
+								"id":   "my-bucket",
+								"name": "assets-bucket",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		graph := BuildGraph(state)
+
+		assert.Len(t, graph.Nodes, 1)
+		assert.Equal(t, "aws_s3_bucket.assets", graph.Nodes[0].ID)
+		assert.Equal(t, "aws_s3_bucket", graph.Nodes[0].Type)
+		assert.Equal(t, "managed", graph.Nodes[0].Mode)
+		assert.Equal(t, "aws", graph.Nodes[0].Provider)
+		assert.Empty(t, graph.Edges)
+	})
+
+	t.Run("resource with module prefix", func(t *testing.T) {
+		state := &models.TerraformState{
+			Resources: []models.ResourceState{
+				{
+					Type:     "aws_instance",
+					Name:     "web",
+					Mode:     "managed",
+					Provider: "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					Module:   "module.app",
+					Instances: []models.ResourceInstance{
+						{
+							Attributes: map[string]any{
+								"id": "i-1234567890",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		graph := BuildGraph(state)
+
+		assert.Len(t, graph.Nodes, 1)
+		assert.Equal(t, "module.app.aws_instance.web", graph.Nodes[0].ID)
+		assert.Equal(t, "module.app", graph.Nodes[0].Module)
+	})
+
+	t.Run("resource with multiple instances creates indexed nodes", func(t *testing.T) {
+		state := &models.TerraformState{
+			Resources: []models.ResourceState{
+				{
+					Type:     "aws_subnet",
+					Name:     "private",
+					Mode:     "managed",
+					Provider: "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					Instances: []models.ResourceInstance{
+						{
+							Attributes: map[string]any{"id": "subnet-1"},
+							IndexKey:   intPtr(0),
+						},
+						{
+							Attributes: map[string]any{"id": "subnet-2"},
+							IndexKey:   intPtr(1),
+						},
+					},
+				},
+			},
+		}
+
+		graph := BuildGraph(state)
+
+		assert.Len(t, graph.Nodes, 2)
+		assert.Equal(t, "aws_subnet.private.[0]", graph.Nodes[0].ID)
+		assert.Equal(t, "aws_subnet.private.[1]", graph.Nodes[1].ID)
+	})
+
+	t.Run("duplicate nodes are not added", func(t *testing.T) {
+		state := &models.TerraformState{
+			Resources: []models.ResourceState{
+				{
+					Type:     "aws_vpc",
+					Name:     "main",
+					Mode:     "managed",
+					Provider: "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					Instances: []models.ResourceInstance{
+						{Attributes: map[string]any{"id": "vpc-1"}},
+					},
+				},
+				{
+					Type:     "aws_vpc",
+					Name:     "main",
+					Mode:     "managed",
+					Provider: "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					Instances: []models.ResourceInstance{
+						{Attributes: map[string]any{"id": "vpc-1"}},
+					},
+				},
+			},
+		}
+
+		graph := BuildGraph(state)
+
+		assert.Len(t, graph.Nodes, 1)
+	})
+
+	t.Run("explicit depends_on creates edges", func(t *testing.T) {
+		state := &models.TerraformState{
+			Resources: []models.ResourceState{
+				{
+					Type:      "aws_instance",
+					Name:      "web",
+					Mode:      "managed",
+					Provider:  "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					DependsOn: []string{"aws_vpc.main"},
+					Instances: []models.ResourceInstance{
+						{Attributes: map[string]any{"id": "i-123"}},
+					},
+				},
+			},
+		}
+
+		graph := BuildGraph(state)
+
+		assert.Len(t, graph.Edges, 1)
+		assert.Equal(t, "aws_instance.web", graph.Edges[0].Source)
+		assert.Equal(t, "aws_vpc.main", graph.Edges[0].Target)
+		assert.Equal(t, "depends_on", graph.Edges[0].Type)
+	})
+
+	t.Run("implicit dependencies create edges", func(t *testing.T) {
+		state := &models.TerraformState{
+			Resources: []models.ResourceState{
+				{
+					Type:     "aws_subnet",
+					Name:     "private",
+					Mode:     "managed",
+					Provider: "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					Instances: []models.ResourceInstance{
+						{
+							Attributes:   map[string]any{"id": "subnet-1"},
+							Dependencies: []string{"aws_vpc.main"},
+						},
+					},
+				},
+			},
+		}
+
+		graph := BuildGraph(state)
+
+		assert.Len(t, graph.Edges, 1)
+		assert.Equal(t, "aws_subnet.private", graph.Edges[0].Source)
+		assert.Equal(t, "aws_vpc.main", graph.Edges[0].Target)
+		assert.Equal(t, "implicit", graph.Edges[0].Type)
+	})
+
+	t.Run("both explicit and implicit dependencies", func(t *testing.T) {
+		state := &models.TerraformState{
+			Resources: []models.ResourceState{
+				{
+					Type:      "aws_instance",
+					Name:      "web",
+					Mode:      "managed",
+					Provider:  "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					DependsOn: []string{"aws_security_group.web"},
+					Instances: []models.ResourceInstance{
+						{
+							Attributes:   map[string]any{"id": "i-123"},
+							Dependencies: []string{"aws_subnet.private"},
+						},
+					},
+				},
+			},
+		}
+
+		graph := BuildGraph(state)
+
+		assert.Len(t, graph.Edges, 2)
+
+		edgeTypes := make(map[string]bool)
+		for _, edge := range graph.Edges {
+			edgeTypes[edge.Type] = true
+		}
+
+		assert.True(t, edgeTypes["depends_on"])
+		assert.True(t, edgeTypes["implicit"])
+	})
+
+	t.Run("data source mode", func(t *testing.T) {
+		state := &models.TerraformState{
+			Resources: []models.ResourceState{
+				{
+					Type:     "aws_ami",
+					Name:     "ubuntu",
+					Mode:     "data",
+					Provider: "provider[\"registry.terraform.io/hashicorp/aws\"]",
+					Instances: []models.ResourceInstance{
+						{Attributes: map[string]any{"id": "ami-123"}},
+					},
+				},
+			},
+		}
+
+		graph := BuildGraph(state)
+
+		assert.Len(t, graph.Nodes, 1)
+		assert.Equal(t, "data", graph.Nodes[0].Mode)
+		assert.Equal(t, "data", graph.Nodes[0].Metadata["mode"])
+	})
+}
+
+func TestBuildNodeID(t *testing.T) {
+	t.Run("simple resource without module", func(t *testing.T) {
+		res := models.ResourceState{
+			Type: "aws_s3_bucket",
+			Name: "assets",
+			Instances: []models.ResourceInstance{
+				{Attributes: map[string]any{}},
+			},
+		}
+
+		id := buildNodeID(res, res.Instances[0], 0)
+
+		assert.Equal(t, "aws_s3_bucket.assets", id)
+	})
+
+	t.Run("resource with module", func(t *testing.T) {
+		res := models.ResourceState{
+			Type:   "aws_instance",
+			Name:   "web",
+			Module: "module.app.module.compute",
+			Instances: []models.ResourceInstance{
+				{Attributes: map[string]any{}},
+			},
+		}
+
+		id := buildNodeID(res, res.Instances[0], 0)
+
+		assert.Equal(t, "module.app.module.compute.aws_instance.web", id)
+	})
+
+	t.Run("resource with multiple instances adds index", func(t *testing.T) {
+		res := models.ResourceState{
+			Type: "aws_subnet",
+			Name: "private",
+			Instances: []models.ResourceInstance{
+				{Attributes: map[string]any{}},
+				{Attributes: map[string]any{}},
+			},
+		}
+
+		id0 := buildNodeID(res, res.Instances[0], 0)
+		id1 := buildNodeID(res, res.Instances[1], 1)
+
+		assert.Equal(t, "aws_subnet.private.[0]", id0)
+		assert.Equal(t, "aws_subnet.private.[1]", id1)
+	})
+
+	t.Run("single instance does not add index", func(t *testing.T) {
+		res := models.ResourceState{
+			Type: "aws_vpc",
+			Name: "main",
+			Instances: []models.ResourceInstance{
+				{Attributes: map[string]any{}},
+			},
+		}
+
+		id := buildNodeID(res, res.Instances[0], 0)
+
+		assert.Equal(t, "aws_vpc.main", id)
+	})
+
+	t.Run("multiple instances with IndexKey use the key instead of index", func(t *testing.T) {
+		res := models.ResourceState{
+			Type: "aws_security_group",
+			Name: "sg",
+			Instances: []models.ResourceInstance{
+				{IndexKey: "frontend", Attributes: map[string]any{}},
+				{IndexKey: "backend", Attributes: map[string]any{}},
+			},
+		}
+
+		id0 := buildNodeID(res, res.Instances[0], 0)
+		id1 := buildNodeID(res, res.Instances[1], 1)
+
+		assert.Equal(t, "aws_security_group.sg.[frontend]", id0)
+		assert.Equal(t, "aws_security_group.sg.[backend]", id1)
+	})
+}
+
+func TestExtractProviderName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "standard AWS provider",
+			input:    "provider[\"registry.terraform.io/hashicorp/aws\"]",
+			expected: "aws",
+		},
+		{
+			name:     "GCP provider",
+			input:    "provider[\"registry.terraform.io/hashicorp/google\"]",
+			expected: "google",
+		},
+		{
+			name:     "Azure provider",
+			input:    "provider[\"registry.terraform.io/hashicorp/azurerm\"]",
+			expected: "azurerm",
+		},
+		{
+			name:     "custom provider with namespace",
+			input:    "provider[\"registry.terraform.io/mycorp/custom\"]",
+			expected: "custom",
+		},
+		{
+			name:     "short format",
+			input:    "provider[\"aws\"]",
+			expected: "aws",
+		},
+		{
+			name:     "already clean name",
+			input:    "aws",
+			expected: "aws",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractProviderName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildMetadata(t *testing.T) {
+	t.Run("includes mode", func(t *testing.T) {
+		res := models.ResourceState{Mode: "managed"}
+		instance := models.ResourceInstance{Attributes: map[string]any{}}
+
+		metadata := buildMetadata(res, instance)
+
+		assert.Equal(t, "managed", metadata["mode"])
+	})
+
+	t.Run("includes id when present", func(t *testing.T) {
+		res := models.ResourceState{Mode: "managed"}
+		instance := models.ResourceInstance{
+			Attributes: map[string]any{
+				"id": "resource-123",
+			},
+		}
+
+		metadata := buildMetadata(res, instance)
+
+		assert.Equal(t, "resource-123", metadata["id"])
+	})
+
+	t.Run("includes name when present", func(t *testing.T) {
+		res := models.ResourceState{Mode: "managed"}
+		instance := models.ResourceInstance{
+			Attributes: map[string]any{
+				"name": "my-resource",
+			},
+		}
+
+		metadata := buildMetadata(res, instance)
+
+		assert.Equal(t, "my-resource", metadata["name"])
+	})
+
+	t.Run("includes arn when present", func(t *testing.T) {
+		res := models.ResourceState{Mode: "managed"}
+		instance := models.ResourceInstance{
+			Attributes: map[string]any{
+				"arn": "arn:aws:s3:::my-bucket",
+			},
+		}
+
+		metadata := buildMetadata(res, instance)
+
+		assert.Equal(t, "arn:aws:s3:::my-bucket", metadata["arn"])
+	})
+
+	t.Run("includes tags when present", func(t *testing.T) {
+		res := models.ResourceState{Mode: "managed"}
+		tags := map[string]any{
+			"Environment": "production",
+			"Owner":       "platform-team",
+		}
+		instance := models.ResourceInstance{
+			Attributes: map[string]any{
+				"tags": tags,
+			},
+		}
+
+		metadata := buildMetadata(res, instance)
+
+		assert.Equal(t, tags, metadata["tags"])
+	})
+
+	t.Run("includes index_key when present", func(t *testing.T) {
+		res := models.ResourceState{Mode: "managed"}
+		indexKey := 42
+		instance := models.ResourceInstance{
+			Attributes: map[string]any{},
+			IndexKey:   &indexKey,
+		}
+
+		metadata := buildMetadata(res, instance)
+
+		assert.Equal(t, &indexKey, metadata["index_key"])
+	})
+
+	t.Run("omits optional fields when not present", func(t *testing.T) {
+		res := models.ResourceState{Mode: "data"}
+		instance := models.ResourceInstance{
+			Attributes: map[string]any{},
+		}
+
+		metadata := buildMetadata(res, instance)
+
+		assert.Equal(t, "data", metadata["mode"])
+		assert.NotContains(t, metadata, "id")
+		assert.NotContains(t, metadata, "name")
+		assert.NotContains(t, metadata, "arn")
+		assert.NotContains(t, metadata, "tags")
+		assert.NotContains(t, metadata, "index_key")
+	})
+
+	t.Run("handles all fields together", func(t *testing.T) {
+		res := models.ResourceState{Mode: "managed"}
+		indexKey := 1
+		instance := models.ResourceInstance{
+			Attributes: map[string]any{
+				"id":   "i-123",
+				"name": "web-server",
+				"arn":  "arn:aws:ec2:us-east-1:123456789012:instance/i-123",
+				"tags": map[string]any{
+					"Name": "web-server",
+				},
+			},
+			IndexKey: &indexKey,
+		}
+
+		metadata := buildMetadata(res, instance)
+
+		assert.Equal(t, "managed", metadata["mode"])
+		assert.Equal(t, "i-123", metadata["id"])
+		assert.Equal(t, "web-server", metadata["name"])
+		assert.Equal(t, "arn:aws:ec2:us-east-1:123456789012:instance/i-123", metadata["arn"])
+		assert.NotNil(t, metadata["tags"])
+		assert.Equal(t, &indexKey, metadata["index_key"])
+	})
+}
+
+func intPtr(i int) *int {
+	return &i
+}

--- a/backend/internal/parser/tfstate.go
+++ b/backend/internal/parser/tfstate.go
@@ -1,0 +1,31 @@
+// Package parser provides utilities for parsing and transforming input data.
+// It handles data normalization, validation, and conversion between formats.
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/terrascope/core/internal/models"
+)
+
+func ParseTfstate(data []byte) (*models.TerraformState, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty tfstate data")
+	}
+
+	var state models.TerraformState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal tfstate: %w", err)
+	}
+
+	if state.Version == 0 {
+		return nil, fmt.Errorf("invalid tfstate: missing version field")
+	}
+
+	if state.TerraformVersion == "" {
+		return nil, fmt.Errorf("invalid tfstate: missing terraform_version field")
+	}
+
+	return &state, nil
+}

--- a/backend/internal/parser/tfstate_test.go
+++ b/backend/internal/parser/tfstate_test.go
@@ -1,0 +1,79 @@
+// Package parser provides utilities for parsing and transforming input data.
+// It handles data normalization, validation, and conversion between formats.
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTfstate_Valid(t *testing.T) {
+	input := []byte(`{
+		"version": 4,
+		"terraform_version": "1.5.0",
+		"serial": 1,
+		"lineage": "abc-123",
+		"resources": [
+			{
+				"mode": "managed",
+				"type": "aws_s3_bucket",
+				"name": "my_bucket",
+				"provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+				"instances": [
+					{
+						"schema_version": 0,
+						"attributes": {
+							"bucket": "my-test-bucket",
+							"region": "us-east-1"
+						}
+					}
+				]
+			}
+		]
+	}`)
+
+	state, err := ParseTfstate(input)
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, state.Version)
+	assert.Equal(t, "1.5.0", state.TerraformVersion)
+	assert.Len(t, state.Resources, 1)
+	assert.Equal(t, "aws_s3_bucket", state.Resources[0].Type)
+	assert.Equal(t, "my_bucket", state.Resources[0].Name)
+}
+
+func TestParseTfstate_Empty(t *testing.T) {
+	_, err := ParseTfstate([]byte{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty tfstate data")
+}
+
+func TestParseTfstate_InvalidJSON(t *testing.T) {
+	_, err := ParseTfstate([]byte(`{invalid json`))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal")
+}
+
+func TestParseTfstate_MissingVersion(t *testing.T) {
+	input := []byte(`{
+		"terraform_version": "1.5.0",
+		"resources": []
+	}`)
+
+	_, err := ParseTfstate(input)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing version")
+}
+
+func TestParseTfstate_MissingTerraformVersion(t *testing.T) {
+	input := []byte(`{
+		"version": 4,
+		"resources": []
+	}`)
+
+	_, err := ParseTfstate(input)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing terraform_version")
+}

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,22 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - 8080:8080
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8080/health",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped


### PR DESCRIPTION
## Description
This PR sets up the initial backend for Terrascope, a stateless microservice that parses Terraform state files and generates interactive infrastructure graphs.

## What's new?
**Backend API**
- Parser: Converts `terraform.tfstate` into a normalized graph structure with nodes (resources) and edges (dependencies)
- HTTP Endpoints:
  - GET `/health` - Health check with version info, uptime, and system details
  - POST `/parse` - Accepts tfstate and returns graph (nodes + edges), with a conditional pretty print
- Models: Type-safe structs for Terraform state and graph representation
- Docker: Multi-stage build with Alpine runtime for minimal image size (~15MB)

**CI/CD**
- GitHub Actions workflow with:
  - Docker image build (tagged with commit SHA)
  - Go tests with module caching (go.mod version detection)
  - Sequential execution: build → test

**Infrastructure**
- compose.yml for local development
- Test files co-located with implementation (*_test.go)